### PR TITLE
Resolved namespace conflict when using lita-time module

### DIFF
--- a/lib/lita/handlers/utc.rb
+++ b/lib/lita/handlers/utc.rb
@@ -6,7 +6,7 @@ module Lita
 
       def utc(request)
 
-        time = Time.now.utc
+        time = ::Time.now.utc
         request.reply("The UTC time and date is now: #{time}")
 
       end


### PR DESCRIPTION
Leaving the Time class unqualified caused problems when a lita bot has also included the lita-time module loaded. This change forces execution of the correct Time class. 
